### PR TITLE
Mostly fix subtle race condition around PRNG init

### DIFF
--- a/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
+++ b/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
@@ -690,8 +690,7 @@ public class AesCbcWithIntegrity {
             Provider[] secureRandomProviders = Security.getProviders("SecureRandom.SHA1PRNG");
             if ((secureRandomProviders == null)
                     || (secureRandomProviders.length < 1)
-                    || (!LinuxPRNGSecureRandomProvider.class.equals(secureRandomProviders[0]
-                            .getClass()))) {
+                    || (!secureRandomProviders[0].getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider"))) {
                 Security.insertProviderAt(new LinuxPRNGSecureRandomProvider(), 1);
             }
 
@@ -699,7 +698,7 @@ public class AesCbcWithIntegrity {
             // SecureRandom.getInstance("SHA1PRNG") return a SecureRandom backed
             // by the Linux PRNG-based SecureRandom implementation.
             SecureRandom rng1 = new SecureRandom();
-            if (!LinuxPRNGSecureRandomProvider.class.equals(rng1.getProvider().getClass())) {
+            if (!rng1.getProvider().getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider")) {
                 throw new SecurityException("new SecureRandom() backed by wrong Provider: "
                         + rng1.getProvider().getClass());
             }
@@ -710,7 +709,7 @@ public class AesCbcWithIntegrity {
             } catch (NoSuchAlgorithmException e) {
                 throw new SecurityException("SHA1PRNG not available", e);
             }
-            if (!LinuxPRNGSecureRandomProvider.class.equals(rng2.getProvider().getClass())) {
+            if (!rng2.getProvider().getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider")) {
                 throw new SecurityException(
                         "SecureRandom.getInstance(\"SHA1PRNG\") backed by wrong" + " Provider: "
                                 + rng2.getProvider().getClass());


### PR DESCRIPTION
Google's PRNG fix can break due to a race condition when two instances
of PrngFixes or PRNGFixes (with different full class name) are running
at the same time.

They both will "fight" over who installs the
LinuxPRNGSecureRandomProvider provider class. Normally, each one will
succeed, check that they succeeded, and then continue on. However,
rarely, one will install its provider while the other is checking
that its installation succeeded, and cause the other to crash.

We now perform a looser check: that the provider's simple name is
merely "LinuxPRNGSecureRandomProvider" instead of checking
for an exact class.

This will fix any instances of the Tozny PrngFixes class from
throwing a SecurityException.

Sadly, though, we cannot figure out a foolproof way to prevent Google's
fix from crashing when the Tozny PrngFixes class initializes 100%
of the time. We have narrowed the race condition window to as
small as possible. But, if you know that other code is installing
a PRNG fix as well, then the best thing to do is to not use
any additional PRNG fix, Tozny's or otherwise.