### PR TITLE
Support obfuscation of PrngFixes inner classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 java-aes-crypto
 ===============
 
-A simple Android class for encrypting &amp; decrypting strings, aiming to avoid [serious cryptographic errors](http://tozny.com/blog/encrypting-strings-in-android-lets-make-better-mistakes/) that most such classes suffer from. [Show me the code](https://github.com/scottyab/java-aes-crypto/blob/master/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java)
+A simple Android class for encrypting &amp; decrypting strings, aiming to avoid [serious cryptographic errors](http://tozny.com/blog/encrypting-strings-in-android-lets-make-better-mistakes/) that most such classes suffer from. [Show me the code](https://github.com/tozny/java-aes-crypto/blob/master/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java)
 
 #Features
 
@@ -17,18 +17,18 @@ Here are the features of this class. We believe that these properties are consis
 #How to include in project?
 
 ###Copy and paste
-It's a single very simple java class, [AesCbcWithIntegrity.java](https://github.com/scottyab/java-aes-crypto/blob/master/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java) that works across most or all versions of Android. The class should be easy to paste into an existing codebase. 
+It's a single very simple java class, [AesCbcWithIntegrity.java](https://github.com/tozny/java-aes-crypto/blob/master/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java) that works across most or all versions of Android. The class should be easy to paste into an existing codebase.
 
 ###Android Library project
 The library is in Android library project format so you can clone this project and add as a library module/project. 
 	
-###Maven Dependancy
-We've also published the library AAR file to Maven central for simple one line gradle dependancy managment. 
+###Maven Dependency
+We've also published the library AAR file to Maven central for simple one line gradle dependency management.
 
 
 ```groovy
 dependencies {
-    compile 'com.scottyab:aes-crypto:0.0.1-SNAPSHOT'
+    compile 'com.tozny:aes-crypto:0.0.1'
 }
 ```
 
@@ -38,7 +38,6 @@ dependencies {
 
 
 ```java
-  AesCbcWithIntegrity.prngFixed.set(true);
   AesCbcWithIntegrity.SecretKeys keys = AesCbcWithIntegrity.generateKey();
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 java-aes-crypto
 ===============
 
+** NOTE: this fork has diverged from original and is publishing to maven central under groupId `com.scottyab` **
+
 A simple Android class for encrypting &amp; decrypting strings, aiming to avoid [serious cryptographic errors](http://tozny.com/blog/encrypting-strings-in-android-lets-make-better-mistakes/) that most such classes suffer from. [Show me the code](https://github.com/tozny/java-aes-crypto/blob/master/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java)
 
 #Features
@@ -28,7 +30,7 @@ We've also published the library AAR file to Maven central for simple one line g
 
 ```groovy
 dependencies {
-    compile 'com.tozny:aes-crypto:0.0.1'
+    compile 'com.scottyab:aes-crypto:0.0.3'
 }
 ```
 

--- a/aes-crypto/aes-crypto.iml
+++ b/aes-crypto/aes-crypto.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>

--- a/aes-crypto/aes-crypto.iml
+++ b/aes-crypto/aes-crypto.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="java-aes-crypto" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":aes-crypto" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -13,8 +13,11 @@
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
-        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugAndroidTestSources" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <afterSyncTasks>
+          <task>generateDebugAndroidTestSources</task>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -24,7 +27,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
     <exclude-output />
@@ -62,6 +65,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/docs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -81,11 +85,14 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
+      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
+      <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
+++ b/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
@@ -23,11 +23,6 @@ public class AesCbcWithIntegrityTest extends AndroidTestCase {
 
         assertEquals("some test", plainText);
 
-<<<<<<< HEAD
-=======
-
-
->>>>>>> 9cd60680b04edd833cd14b3f65f0578762b7da83
     }
 
 }

--- a/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
+++ b/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
@@ -25,4 +25,36 @@ public class AesCbcWithIntegrityTest extends AndroidTestCase {
 
     }
 
+
+    public void testEncryptionDecryptionWithPassword() throws Exception {
+        AesCbcWithIntegrity.SecretKeys keys = AesCbcWithIntegrity.generateKeyFromPassword("mypassword", "salty".getBytes());
+
+        //encrypt
+        AesCbcWithIntegrity.CipherTextIvMac cipherTextIvMac = AesCbcWithIntegrity.encrypt("some test", keys);
+        //store or send to server
+        String ciphertextString = cipherTextIvMac.toString();
+
+        //decrypt
+        String plainText = AesCbcWithIntegrity.decryptString(cipherTextIvMac, keys);
+
+        assertEquals("some test", plainText);
+
+    }
+
+    public void testEncryptionDecryptionCustomIterationCount() throws Exception {
+        AesCbcWithIntegrity.SecretKeys keys = AesCbcWithIntegrity.generateKeyFromPassword("mypassword", "salty".getBytes(), 1000);
+
+        //encrypt
+        AesCbcWithIntegrity.CipherTextIvMac cipherTextIvMac = AesCbcWithIntegrity.encrypt("some test", keys);
+        //store or send to server
+        String ciphertextString = cipherTextIvMac.toString();
+
+        //decrypt
+        String plainText = AesCbcWithIntegrity.decryptString(cipherTextIvMac, keys);
+
+        assertEquals("some test", plainText);
+
+    }
+
+
 }

--- a/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
+++ b/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
@@ -12,8 +12,16 @@ public class AesCbcWithIntegrityTest extends AndroidTestCase {
 
     public void testEncryptionDecryptionWorks() throws Exception {
         AesCbcWithIntegrity.SecretKeys keys = AesCbcWithIntegrity.generateKey();
-        String plain = AesCbcWithIntegrity.decryptString(AesCbcWithIntegrity.encrypt("some test", keys), keys);
-        assertEquals("some test", plain);
+
+        //encrypt
+        AesCbcWithIntegrity.CipherTextIvMac cipherTextIvMac = AesCbcWithIntegrity.encrypt("some test", keys);
+        //store or send to server
+        String ciphertextString = cipherTextIvMac.toString();
+
+        //decrypt
+        String plainText = AesCbcWithIntegrity.decryptString(cipherTextIvMac, keys);
+
+        assertEquals("some test", plainText);
 
     }
 

--- a/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
+++ b/aes-crypto/src/androidTest/java/com/tozny/crypto/android/AesCbcWithIntegrityTest.java
@@ -57,4 +57,14 @@ public class AesCbcWithIntegrityTest extends AndroidTestCase {
     }
 
 
+    public void testEncryptionDecryptionWithDodgySalt() throws Exception {
+        try {
+            AesCbcWithIntegrity.SecretKeys keys = AesCbcWithIntegrity.generateKeyFromPassword("mypassword", "ABCD + == + EFG!@$%£|~%  ^%$");
+            fail("Salt contains invalid base64 chars, an error should be thrown but wasn't");
+        }catch (IllegalArgumentException e){
+            //ignore this should happen
+        }
+
+    }
+
 }

--- a/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
+++ b/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
@@ -72,20 +72,12 @@ public class AesCbcWithIntegrity {
     private static final int PBE_ITERATION_COUNT = 10000;
     private static final int PBE_SALT_LENGTH_BITS = AES_KEY_LENGTH_BITS; // same size as key output
     private static final String PBE_ALGORITHM = "PBKDF2WithHmacSHA1";
-<<<<<<< HEAD:aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
 
     //Made BASE_64_FLAGS public as it's useful to know for compatibility.
     public static final int BASE64_FLAGS = Base64.NO_WRAP;
-
     //default for testing
     static final AtomicBoolean prngFixed = new AtomicBoolean(false);
 
-=======
-    public static final int BASE64_FLAGS = Base64.DEFAULT | Base64.NO_WRAP;
-
-    //default for testing
-    static final AtomicBoolean prngFixed = new AtomicBoolean(false);
->>>>>>> 9cd60680b04edd833cd14b3f65f0578762b7da83:aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final int HMAC_KEY_LENGTH_BITS = 256;
 

--- a/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
+++ b/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
@@ -699,6 +699,7 @@ public class AesCbcWithIntegrity {
             }
 
             try {
+                //Log.i(PrngFixes.class.getSimpleName(), "applying OpenSSLFix");
                 // Mix in the device- and invocation-specific seed.
                 Class.forName("org.apache.harmony.xnet.provider.jsse.NativeCrypto")
                         .getMethod("RAND_seed", byte[].class).invoke(null, generateSeed());
@@ -735,6 +736,7 @@ public class AesCbcWithIntegrity {
                 return;
             }
 
+            //Log.i(PrngFixes.class.getSimpleName(), "Applying the  Linux PRNG-based SecureRandom to fix PRNG");
             // Install a Linux PRNG-based SecureRandom implementation as the
             // default, if not yet installed.
             Provider[] secureRandomProviders = Security.getProviders("SecureRandom.SHA1PRNG");
@@ -747,7 +749,8 @@ public class AesCbcWithIntegrity {
             synchronized (java.security.Security.class) {
                 if ((secureRandomProviders == null)
                         || (secureRandomProviders.length < 1)
-                        || (!secureRandomProviders[0].getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider"))) {
+                        || (!secureRandomProviders[0].getClass().getSimpleName().equals(LinuxPRNGSecureRandomProvider.class.getSimpleName()))) {
+                    //Log.i(PrngFixes.class.getSimpleName(), "inserting new PRNG provider at pos 1: [" + LinuxPRNGSecureRandomProvider.class.getSimpleName() +"]");
                     Security.insertProviderAt(new LinuxPRNGSecureRandomProvider(), 1);
                 }
 
@@ -755,7 +758,7 @@ public class AesCbcWithIntegrity {
                 // SecureRandom.getInstance("SHA1PRNG") return a SecureRandom backed
                 // by the Linux PRNG-based SecureRandom implementation.
                 SecureRandom rng1 = new SecureRandom();
-                if (!rng1.getProvider().getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider")) {
+                if (!rng1.getProvider().getClass().getSimpleName().equals(LinuxPRNGSecureRandomProvider.class.getSimpleName())) {
                     if (ALLOW_BROKEN_PRNG) {
                         Log.w(PrngFixes.class.getSimpleName(),
                                 "new SecureRandom() backed by wrong Provider: " + rng1.getProvider().getClass());
@@ -777,7 +780,7 @@ public class AesCbcWithIntegrity {
                         new SecurityException("SHA1PRNG not available", e);
                     }
                 }
-                if (!rng2.getProvider().getClass().getSimpleName().equals("LinuxPRNGSecureRandomProvider")) {
+                if (!rng2.getProvider().getClass().getSimpleName().equals(LinuxPRNGSecureRandomProvider.class.getSimpleName())) {
                     if (ALLOW_BROKEN_PRNG) {
                         Log.w(PrngFixes.class.getSimpleName(),
                                 "SecureRandom.getInstance(\"SHA1PRNG\") backed by wrong" + " Provider: "
@@ -796,6 +799,7 @@ public class AesCbcWithIntegrity {
          * {@code Provider} of {@code SecureRandom} engines which pass through
          * all requests to the Linux PRNG.
          */
+
         private static class LinuxPRNGSecureRandomProvider extends Provider {
 
             public LinuxPRNGSecureRandomProvider() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.0.2-SNAPSHOT
-#VERSION_NAME=0.0.1
-VERSION_CODE=2
+VERSION_NAME=0.0.3
+VERSION_CODE=3
 GROUP=com.scottyab
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.0.3
-VERSION_CODE=3
+VERSION_NAME=0.0.4
+VERSION_CODE=4
 GROUP=com.scottyab
 
 

--- a/java-aes-crypto.iml
+++ b/java-aes-crypto.iml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="java-aes-crypto" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
@@ -16,4 +17,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/java-aes-crypto.iml
+++ b/java-aes-crypto.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,8 +28,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    //compile project (':aes-crypto')
-    compile 'com.scottyab:aes-crypto:0.0.1-SNAPSHOT'
+    compile project (':aes-crypto')
 
     compile 'com.android.support:appcompat-v7:21.0.3'
 }

--- a/sample/sample.iml
+++ b/sample/sample.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="java-aes-crypto" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":sample" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -13,8 +13,11 @@
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
-        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugAndroidTestSources" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <afterSyncTasks>
+          <task>generateDebugAndroidTestSources</task>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -23,7 +26,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/debug" />
     <exclude-output />
@@ -81,6 +84,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
+      <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
@@ -91,4 +96,3 @@
     <orderEntry type="module" module-name="aes-crypto" exported="" />
   </component>
 </module>
-

--- a/sample/sample.iml
+++ b/sample/sample.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.scottyab" external.system.module.version="0.0.2-SNAPSHOT" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -90,7 +90,7 @@
     <orderEntry type="library" exported="" name="appcompat-v7-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="support-v4-21.0.3" level="project" />
-    <orderEntry type="library" exported="" name="aes-crypto-0.0.1-SNAPSHOT" level="project" />
+    <orderEntry type="module" module-name="aes-crypto" exported="" />
   </component>
 </module>
 


### PR DESCRIPTION
Changed the equals check to use LinuxPRNGSecureRandomProvider.class.getSimpleName() rather than "LinuxPRNGSecureRandomProvider". This way it doesn't matter if proguard (or whatever) changes the class name. Related to scottyab/secure-preferences#31

Includes @cermak's PR to Add iteration count to generateKeyFromPassword method. 
