### PR TITLE
fix typo in error message

### DIFF
--- a/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
+++ b/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
@@ -522,7 +522,7 @@ public class AesCbcWithIntegrity {
         public CipherTextIvMac(String base64IvAndCiphertext) {
             String[] civArray = base64IvAndCiphertext.split(":");
             if (civArray.length != 3) {
-                throw new IllegalArgumentException("Cannot parse iv:ciphertext:mac");
+                throw new IllegalArgumentException("Cannot parse iv:mac:ciphertext");
             } else {
                 iv = Base64.decode(civArray[0], BASE64_FLAGS);
                 mac = Base64.decode(civArray[1], BASE64_FLAGS);


### PR DESCRIPTION
I believe this is a typo; the code expects the mac to come before the cipher.